### PR TITLE
Add setting to optionally split at the end of the intro section

### DIFF
--- a/doom2016.asl
+++ b/doom2016.asl
@@ -261,8 +261,6 @@ startup {
     };
 }
 
-
-
 init {
     vars.hasSplitForIntro = false;
 
@@ -405,16 +403,18 @@ split {
             // Track to prevent splitting twice in 100%
             vars.visitedMapFiles.Add(current.mapFile);
             return true;
-        }  else if (!vars.hasSplitForIntro && settings["splitForIntro"]) { // Optional intro split when smashing the panel
-            bool inUAC = current.mapFile.Equals("game/sp/intro/intro");
-            bool correctIntroSplitXPos = Math.Abs(vars.playerX - (-10152.54)) < 0.1;
-            bool correctIntroSplitYPos = Math.Abs(vars.playerY - (-2685.575)) < 0.1;
-            bool correctIntroSplitZPos = Math.Abs(vars.playerZ - 3148.311) < 0.1;
-            bool correctIntroSplitPos = correctIntroSplitXPos && correctIntroSplitYPos && correctIntroSplitZPos;
+        }  else if (version == "6, 1, 1, 321") {
+            if (!vars.hasSplitForIntro && settings["splitForIntro"]) { // Optional intro split when smashing the panel
+                bool inUAC = current.mapFile.Equals("game/sp/intro/intro");
+                bool correctIntroSplitXPos = Math.Abs(vars.playerX - (-10152.54)) < 0.1;
+                bool correctIntroSplitYPos = Math.Abs(vars.playerY - (-2685.575)) < 0.1;
+                bool correctIntroSplitZPos = Math.Abs(vars.playerZ - 3148.311) < 0.1;
+                bool correctIntroSplitPos = correctIntroSplitXPos && correctIntroSplitYPos && correctIntroSplitZPos;
 
-            if (inUAC && correctIntroSplitPos) {
-                vars.hasSplitForIntro = true;
-                return true;
+                if (inUAC && correctIntroSplitPos) {
+                    vars.hasSplitForIntro = true;
+                    return true;
+                }
             }
         }
         return false;

--- a/doom2016.asl
+++ b/doom2016.asl
@@ -10,24 +10,24 @@
 // probably more
 
 //===NOTES AND CHANGELOG===//
-//heny						@21\08\20:	Updated the splitter for the latest 6,1,1,321 version to support OpenGL + added setting to optionally split between Lazarus Labs 1 & 2
-//Glurmo						@23\01\19:	Removed steam api ("tier0_s64.dll") dependency to prevent steam client updates breaking autosplitter + Add NG+ support
-//Glurmo						@21\01\19:	Fixed map name pointer for steam update (4.89.17.15) + added skipping of rune loadscreens for 100%
-//Instagibz						@04\04\18:	Updated the splitter for latest 6,1,1,321 version, VULKAN only
-//Loitho						@13\10\17:	Fixed mapname variable. Invalid pointer caused by a steam update of the tier0_s64.dll | Works for Steam >= 4.17.60.88
-//Loitho						@09\09\17:	Fixed the splitter for auto split on last boss hit 6,1,1,818 - Vulkan only
-//blairmadison11				@02\09\17:	Partially updated the splitter for the latest 6,1,1,818, VULKAN only
-//Instagibz & blairmadison11	@22\07\17:	Updated the splitter for the latest 6,1,1,513 version, VULKAN only for now. Note: Versioning changed back from 6,1,1,1219 to 6,1,1,513
-//Instagibz                     @29\01\17:	Updated the splitter for latest steam-api change
-//Instagibz						@20\12\16:	Updated the splitter for latest 6,1,1,1219 version, VULKAN only for now
-//Instagibz						@08\12\16:	Updated the splitter for latest 6,1,1,1201 version, VULKAN only for now
-//Instagibz						@14\11\16:	Updated the splitter for latest 6,1,1,1109 version
-//Instagibz						@19\10\16:	Updated the splitter for latest 6,1,1,1012 version
-//Instagibz						@30\09\16:	Added auto-end to 6,1,1,706 also changed auto-start, was broken for me a few times
-//TheFuncannon					@30\09\16:	Updated the OGL version 6,1,1,706 to auto-start 
-//Instagibz						@30\09\16:	Updated the vulkan and OGL version 6,1,1,920 to auto-start, auto-split and auto-end the run. Requires 13 splits 
+//heny                          @21\08\20:  Added setting to optionally split at the end of the intro section
+//heny                          @21\08\20:  Updated the splitter for the latest 6,1,1,321 version to support OpenGL + added setting to optionally split between Lazarus Labs 1 & 2
+//Glurmo                        @23\01\19:  Removed steam api ("tier0_s64.dll") dependency to prevent steam client updates breaking autosplitter + Add NG+ support
+//Glurmo                        @21\01\19:  Fixed map name pointer for steam update (4.89.17.15) + added skipping of rune loadscreens for 100%
+//Instagibz                     @04\04\18:  Updated the splitter for latest 6,1,1,321 version, VULKAN only
+//Loitho                        @13\10\17:  Fixed mapname variable. Invalid pointer caused by a steam update of the tier0_s64.dll | Works for Steam >= 4.17.60.88
+//Loitho                        @09\09\17:  Fixed the splitter for auto split on last boss hit 6,1,1,818 - Vulkan only
+//blairmadison11                @02\09\17:  Partially updated the splitter for the latest 6,1,1,818, VULKAN only
+//Instagibz & blairmadison11    @22\07\17:  Updated the splitter for the latest 6,1,1,513 version, VULKAN only for now. Note: Versioning changed back from 6,1,1,1219 to 6,1,1,513
+//Instagibz                     @29\01\17:  Updated the splitter for latest steam-api change
+//Instagibz                     @20\12\16:  Updated the splitter for latest 6,1,1,1219 version, VULKAN only for now
+//Instagibz                     @08\12\16:  Updated the splitter for latest 6,1,1,1201 version, VULKAN only for now
+//Instagibz                     @14\11\16:  Updated the splitter for latest 6,1,1,1109 version
+//Instagibz                     @19\10\16:  Updated the splitter for latest 6,1,1,1012 version
+//Instagibz                     @30\09\16:  Added auto-end to 6,1,1,706 also changed auto-start, was broken for me a few times
+//TheFuncannon                  @30\09\16:  Updated the OGL version 6,1,1,706 to auto-start
+//Instagibz                     @30\09\16:  Updated the vulkan and OGL version 6,1,1,920 to auto-start, auto-split and auto-end the run. Requires 13 splits
 //===NOTES AND CHANGELOG===//
-
 
 state("DOOMx64", "6, 1, 1, 527") {
     bool isLoading: 0x308C930;
@@ -44,12 +44,12 @@ state("DOOMx64", "6, 1, 1, 706") {
     // (You have to press space)
     // So basically here you can chill during loading
     bool isLoading: 0x31D3B10;
-    
+
     // Timer restart when "real" loading is finished
     // (even if you don't press space, the time WILL start)
     // Here you need to spam the spacebar during loading screen
     // bool isLoading: 0xB99B1E4;
-    
+
     bool canStart: 0x297CF3A;
     bool start: 0x34C5304;
     bool finalHit: 0x31D3F74;
@@ -86,7 +86,7 @@ state("DOOMx64vk", "6, 1, 1, 920") {
 }
 
 state("DOOMx64", "6, 1, 1, 1012") {
-    float bossHealth: 0x0330D838, 0x30, 0x4E8, 0x2E0, 0x1B8; 
+    float bossHealth: 0x0330D838, 0x30, 0x4E8, 0x2E0, 0x1B8;
     bool start: 0x362E9BC;
     bool canStart: 0x2A4D304;
     bool finalHit: 0x3315AF4;
@@ -104,7 +104,7 @@ state("DOOMx64vk", "6, 1, 1, 1012") {
 }
 
 state("DOOMx64", "6, 1, 1, 1109") {
-    float bossHealth: 0x0330D838, 0x30, 0x4E8, 0x2E0, 0x1B8; 
+    float bossHealth: 0x0330D838, 0x30, 0x4E8, 0x2E0, 0x1B8;
     bool start: 0x362E9BC;
     bool canStart: 0x2A4D304;
     bool finalHit: 0x3315AF4;
@@ -128,42 +128,42 @@ state("DOOMx64", "6, 1, 1, 1201") {
     bool finalHit: 0x3315AF4;                                       //NOT UPDATED YET
     bool isLoading: 0x3315690;                                      //NOT UPDATED YET
     string35 mapName: "tier0_s64.dll", 0x4E170, 0x17;               //NOT UPDATED YET
-}                                                                   
+}
 
 state("DOOMx64vk", "6, 1, 1, 1201") {
-    float bossHealth: 0x04C08DC0, 0x30, 0x4E8, 0x2E0, 0x1B4;      
-    bool start: 0x5684168;                          		
-    bool canStart: 0x2C14A44;                       		
-    bool finalHit: 0x535F274;                       		
-    bool isLoading: 0x535EE10;                      		
-    string35 mapName: "tier0_s64.dll", 0x4E170, 0x17;  		
+    float bossHealth: 0x04C08DC0, 0x30, 0x4E8, 0x2E0, 0x1B4;
+    bool start: 0x5684168;
+    bool canStart: 0x2C14A44;
+    bool finalHit: 0x535F274;
+    bool isLoading: 0x535EE10;
+    string35 mapName: "tier0_s64.dll", 0x4E170, 0x17;
 }
 
 state("DOOMx64", "6, 1, 1, 1219") {
     float bossHealth: 0x04C08DC0, 0x30, 0x4E8, 0x2E0, 0x1B4;        //NOT UPDATED YET
-    bool start: 0x5684168;                          				//NOT UPDATED YET
-    bool canStart: 0x2C14A44;                       				//NOT UPDATED YET
-    bool finalHit: 0x535F274;                       				//NOT UPDATED YET
-    bool isLoading: 0x535EE10;                      				//NOT UPDATED YET
-    string35 mapName: "tier0_s64.dll", 0x4E170, 0x17;  				//NOT UPDATED YET
+    bool start: 0x5684168;                                          //NOT UPDATED YET
+    bool canStart: 0x2C14A44;                                       //NOT UPDATED YET
+    bool finalHit: 0x535F274;                                       //NOT UPDATED YET
+    bool isLoading: 0x535EE10;                                      //NOT UPDATED YET
+    string35 mapName: "tier0_s64.dll", 0x4E170, 0x17;               //NOT UPDATED YET
 }
 
 state("DOOMx64vk", "6, 1, 1, 1219") {
-    float bossHealth: 0x04C08DC0, 0x30, 0x4E8, 0x2E0, 0x1B4;      
-    bool start: 0x5684168;                          		
-    bool canStart: 0x2C14A44;                       		
-    bool finalHit: 0x535F274;                       		
-    bool isLoading: 0x535EE10;                      		
-    string35 mapName: "tier0_s64.dll", 0x4E170, 0x17;  		
+    float bossHealth: 0x04C08DC0, 0x30, 0x4E8, 0x2E0, 0x1B4;
+    bool start: 0x5684168;
+    bool canStart: 0x2C14A44;
+    bool finalHit: 0x535F274;
+    bool isLoading: 0x535EE10;
+    string35 mapName: "tier0_s64.dll", 0x4E170, 0x17;
 }
 
 state("DOOMx64", "6, 1, 1, 531") {
     float bossHealth: 0x04C08DC0, 0x30, 0x4E8, 0x2E0, 0x1B4;        //NOT UPDATED YET
-    bool start: 0x57BDEE0;                          				//NOT UPDATED YET
-    bool canStart: 0x54DC3D8;                       				//NOT UPDATED YET
-    bool finalHit: 0x535F274;                       				//NOT UPDATED YET
-    bool isLoading: 0x56844C9;                      				//NOT UPDATED YET
-    string35 mapName: "tier0_s64.dll", 0x4E170, 0x17;  				//NOT UPDATED YET
+    bool start: 0x57BDEE0;                                          //NOT UPDATED YET
+    bool canStart: 0x54DC3D8;                                       //NOT UPDATED YET
+    bool finalHit: 0x535F274;                                       //NOT UPDATED YET
+    bool isLoading: 0x56844C9;                                      //NOT UPDATED YET
+    string35 mapName: "tier0_s64.dll", 0x4E170, 0x17;               //NOT UPDATED YET
 }
 
 state("DOOMx64vk", "6, 1, 1, 531") {
@@ -177,12 +177,12 @@ state("DOOMx64vk", "6, 1, 1, 531") {
 
 // 2017-08-24 Patch
 state("DOOMx64vk", "6, 1, 1, 818") {
-    float bossHealth: 0x2B0F3C0, 0x2CD80, 0x2B78; 		// Fixed
-    bool start: 0x5686EE0;								// confirmed working
-    bool canStart: 0x53A53D8;							// confirmed working
-    bool finalHit: 0x528EDB4;							// confirmed working
-    bool isLoading: 0x554D4C9;							// confirmed working
-    
+    float bossHealth: 0x2B0F3C0, 0x2CD80, 0x2B78;       // Fixed
+    bool start: 0x5686EE0;                              // confirmed working
+    bool canStart: 0x53A53D8;                           // confirmed working
+    bool finalHit: 0x528EDB4;                           // confirmed working
+    bool isLoading: 0x554D4C9;                          // confirmed working
+
     string35 mapName: "tier0_s64.dll", 0x58180, 0x17;
     string60 mapFile: 0x556B325;
 }
@@ -212,7 +212,36 @@ state("DOOMx64vk", "6, 1, 1, 321") {
 }
 
 startup {
-    settings.Add("splitBetweenLazarusLabs1And2", false, "Split between Lazarus Labs 1 & 2");
+    vars.readOffset = (Func<Process, IntPtr, int, int, IntPtr>)((proc, ptr, offsetSize, remainingBytes) => {
+        byte[] offsetBytes;
+        if (ptr == IntPtr.Zero || !proc.ReadBytes(ptr, offsetSize, out offsetBytes)) {
+            return IntPtr.Zero;
+        }
+
+        int offset;
+        switch (offsetSize) {
+            case 1:
+                offset = offsetBytes[0];
+                break;
+            case 2:
+                offset = BitConverter.ToInt16(offsetBytes, 0);
+                break;
+            case 4:
+                offset = BitConverter.ToInt32(offsetBytes, 0);
+                break;
+            default:
+                throw new Exception("Unsupported offset size");
+        }
+
+        return ptr + offsetSize + remainingBytes + offset;
+    });
+
+    settings.Add("optionalSplits", false, "Optional Splits (Game Version 6, 1, 1, 321)");
+    settings.Add("splitForIntro", false, "Intro", "optionalSplits");
+    settings.Add("splitForLazarusLabs1", false, "Lazarus Labs 1", "optionalSplits");
+    settings.SetToolTip("optionalSplits", "Optionally split for special situations/in special locations (currently only working on game version 6, 1, 1, 321)");
+    settings.SetToolTip("splitForIntro", "Split when smashing the elevator button panel in the intro section");
+    settings.SetToolTip("splitForLazarusLabs1", "Split at the end of the first part of Lazarus Labs");
 
     vars.visitedMapFiles = new List<string>();
     vars.introMapFile = "game/sp/intro/intro"; // UAC
@@ -232,22 +261,64 @@ startup {
     };
 }
 
+
+
 init {
-    version = modules.First().FileVersionInfo.FileVersion;
+    vars.hasSplitForIntro = false;
+
+    vars.playerPosPtr = 0;
+    vars.playerX = 0.0;
+    vars.playerY = 0.0;
+    vars.playerZ = 0.0;
+
+    var firstModule = modules.First();
+    version = firstModule.FileVersionInfo.FileVersion;
+
+    if (version == "6, 1, 1, 321") {
+        // Delay signature scanning slightly to wait for the game's memory to be properly accessible
+        vars.sigScanDelay = new System.Threading.Timer(_ => {
+            var playerSigTarget = new SigScanTarget(3, "48 03 0D ?? ?? ?? ?? 39 01");
+            var sigScanner = new SignatureScanner(game, firstModule.BaseAddress, firstModule.ModuleMemorySize);
+            var playerSigPtr = sigScanner.Scan(playerSigTarget);
+            vars.playerSigAddr = vars.readOffset(game, playerSigPtr, sizeof(int), 0);
+        }, null, 3000, Timeout.Infinite);
+    }
+
     print(version);
 }
 
-exit { timer.IsGameTimePaused = true; }
+update {
+    if (version == "6, 1, 1, 321" && settings["splitForIntro"]) { // Untested for other versions at the moment
+        if (old.isLoading && !current.isLoading) {
+            var playerBasePtr = new DeepPointer(vars.playerSigAddr, 0x8, 0x808, 0x1AB8);
+            IntPtr playerPosPtr;
+            playerBasePtr.DerefOffsets(game, out playerPosPtr);
+            vars.playerPosPtr = playerPosPtr;
+        }
+
+        if (timer.CurrentPhase == TimerPhase.Running && !vars.hasSplitForIntro && !current.isLoading) {
+            vars.playerX = memory.ReadValue<float>((IntPtr)vars.playerPosPtr);
+            vars.playerY = memory.ReadValue<float>((IntPtr)vars.playerPosPtr + 4);
+            vars.playerZ = memory.ReadValue<float>((IntPtr)vars.playerPosPtr + 8);
+        }
+    }
+}
+
+exit {
+    timer.IsGameTimePaused = true;
+    vars.sigScanDelay.Dispose();
+}
 
 start {
+    vars.hasSplitForIntro = false;
     vars.visitedMapFiles = new List<string>();
 
-    if (settings["splitBetweenLazarusLabs1And2"]) {
+    if (settings["splitForLazarusLabs1"]) {
         vars.mapFileSplits.Add("game/sp/lazarus_2/lazarus_2");
     } else {
         vars.mapFileSplits.Remove("game/sp/lazarus_2/lazarus_2");
     }
-		
+
     if (version == "6, 1, 1, 527") {
         return (
             !old.start &&
@@ -286,7 +357,7 @@ split {
             !old.mainMenu
         ) || (
             !current.finalHit &&
-            current.bossHealth == 1);	
+            current.bossHealth == 1);
     } else if (version == "6, 1, 1, 808") {
         return (
             !String.IsNullOrEmpty(current.mapName) &&
@@ -334,6 +405,17 @@ split {
             // Track to prevent splitting twice in 100%
             vars.visitedMapFiles.Add(current.mapFile);
             return true;
+        }  else if (!vars.hasSplitForIntro && settings["splitForIntro"]) { // Optional intro split when smashing the panel
+            bool inUAC = current.mapFile.Equals("game/sp/intro/intro");
+            bool correctIntroSplitXPos = Math.Abs(vars.playerX - (-10152.54)) < 0.1;
+            bool correctIntroSplitYPos = Math.Abs(vars.playerY - (-2685.575)) < 0.1;
+            bool correctIntroSplitZPos = Math.Abs(vars.playerZ - 3148.311) < 0.1;
+            bool correctIntroSplitPos = correctIntroSplitXPos && correctIntroSplitYPos && correctIntroSplitZPos;
+
+            if (inUAC && correctIntroSplitPos) {
+                vars.hasSplitForIntro = true;
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
The easiest way to detect the "button smash" at the end of the intro is by comparing the current player position with (-10152.54, -2685.575, 3148.311). As the player position struct location in memory changes when the game is loading a map, the respective pointer path needs to be dereferenced every time this happens.

At the moment the optional splits are only tested and thus supported for the latest version of the game on Steam.